### PR TITLE
标注 eval(outputs) 在非字典输出下会崩溃

### DIFF
--- a/DeepSeek-OCR2-master/DeepSeek-OCR2-vllm/run_dpsk_ocr2_image.py
+++ b/DeepSeek-OCR2-master/DeepSeek-OCR2-vllm/run_dpsk_ocr2_image.py
@@ -252,6 +252,7 @@ if __name__ == "__main__":
         if 'line_type' in outputs:
             import matplotlib.pyplot as plt
             from matplotlib.patches import Circle
+            # WARNING: outputs is free-form model text; eval(outputs) can crash if it's not a valid dict.
             lines = eval(outputs)['Line']['line']
 
             line_type = eval(outputs)['Line']['line_type']


### PR DESCRIPTION
## 问题
- OCR 输出是自由文本，但代码里直接对 `outputs` 执行 `eval(outputs)`。
- 当输出包含 `line_type` 等字段、但整体不是合法 Python dict 时，`eval` 会抛异常并导致程序崩溃。

## 复现方式
- 运行 `run_dpsk_ocr2_image.py`。
- 输入包含 `line_type` 的非结构化 OCR 文本（见下方截图）。

## 根因与建议
- 根因在 `modeling_deepseekocr2.py` 内部对 `outputs` 的 `eval` 调用。
- 建议在源码侧用安全解析（如 `ast.literal_eval` + 失败兜底）替换直接 `eval`。
- 修改 HF 缓存只是临时 workaround，最佳做法是在源码仓库修复。
## 说明
此处只提交一行注释，是因为根因在 HF 模型源码（`modeling_deepseekocr2.py`）而非本仓库脚本；真正修复应在模型仓库替换 `eval(outputs)`。

复现所用图片：  
<img width="500" height="500" alt="ceshi" src="https://github.com/user-attachments/assets/97185b9d-a96c-48d4-9067-6543eb8b1726" />

错误日志图片：  
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/d18e038b-bf8e-4004-8e49-97d381ea0489" />
