### PR TITLE
Fix fragile filename generation in run_dpsk_ocr2_pdf.py

### DIFF
--- a/DeepSeek-OCR2-master/DeepSeek-OCR2-vllm/run_dpsk_ocr2_pdf.py
+++ b/DeepSeek-OCR2-master/DeepSeek-OCR2-vllm/run_dpsk_ocr2_pdf.py
@@ -276,9 +276,10 @@ if __name__ == "__main__":
     os.makedirs(output_path, exist_ok=True)
 
 
-    mmd_det_path = output_path + '/' + INPUT_PATH.split('/')[-1].replace('.pdf', '_det.mmd')
-    mmd_path = output_path + '/' + INPUT_PATH.split('/')[-1].replace('pdf', 'mmd')
-    pdf_out_path = output_path + '/' + INPUT_PATH.split('/')[-1].replace('.pdf', '_layouts.pdf')
+    base_name = os.path.splitext(os.path.basename(INPUT_PATH))[0]
+    mmd_det_path = os.path.join(output_path, f'{base_name}_det.mmd')
+    mmd_path = os.path.join(output_path, f'{base_name}.mmd')
+    pdf_out_path = os.path.join(output_path, f'{base_name}_layouts.pdf')
     contents_det = ''
     contents = ''
     draw_images = []


### PR DESCRIPTION
Improves the  output filename generation by using os.path instead of manual string replacements.

Ran into a small bug, so I tried a file named financial_pdf_report.pdf.
Bug: The output file becomes financial_mmd_report.mmd. This is unexpected and confusing behavior.
Issue 2: Also important to notice manual string concatenation using / might fail or behave unexpectedly on Windows systems.

Solution: Just refactored to use standard os.path library functions:

Used os.path.basename and os.path.splitext to safely isolate the filename and extension.
Used os.path.join to construct paths, ensuring cross-platform compatibility.

 The previous implementation used str.replace('pdf', 'mmd') on the entire filename string. 

