### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/DeepSeek-OCR2-master/DeepSeek-OCR2-vllm/run_dpsk_ocr2_image.py
+++ b/DeepSeek-OCR2-master/DeepSeek-OCR2-vllm/run_dpsk_ocr2_image.py
@@ -38,7 +38,7 @@ def load_image(image_path):
         print(f"error: {e}")
         try:
             return Image.open(image_path)
-        except:
+        except Exception:
             return None
 
 
@@ -128,9 +128,9 @@ def draw_bounding_boxes(image, refs):
                                     fill=(255, 255, 255, 30))
                         
                         draw.text((text_x, text_y), label_type, font=font, fill=color)
-                    except:
+                    except Exception:
                         pass
-        except:
+        except Exception:
             continue
     img_draw.paste(overlay, (0, 0), overlay)
     return img_draw
@@ -275,7 +275,7 @@ if __name__ == "__main__":
 
                     ax.scatter(p0[0], p0[1], s=5, color = 'k')
                     ax.scatter(p1[0], p1[1], s=5, color = 'k')
-                except:
+                except Exception:
                     pass
 
             for endpoint in endpoints:
@@ -294,7 +294,7 @@ if __name__ == "__main__":
                         center = eval(center.split(': ')[1])
                         circle = Circle(center, radius=r, fill=False, edgecolor='black', linewidth=0.8)
                         ax.add_patch(circle)
-            except:
+            except Exception:
                 pass
 
 

--- a/DeepSeek-OCR2-master/DeepSeek-OCR2-vllm/run_dpsk_ocr2_pdf.py
+++ b/DeepSeek-OCR2-master/DeepSeek-OCR2-vllm/run_dpsk_ocr2_pdf.py
@@ -207,9 +207,9 @@ def draw_bounding_boxes(image, refs, jdx):
                                     fill=(255, 255, 255, 30))
                         
                         draw.text((text_x, text_y), label_type, font=font, fill=color)
-                    except:
+                    except Exception:
                         pass
-        except:
+        except Exception:
             continue
     img_draw.paste(overlay, (0, 0), overlay)
     return img_draw


### PR DESCRIPTION
Replace 7 bare `except:` in vllm inference scripts with `except Exception:` to avoid catching `SystemExit`/`KeyboardInterrupt` during batch OCR processing.